### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/stupid.js
+++ b/stupid.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const fs = require('fs');
 const vm = require('vm');
+const path = require('path');
 const app = express();
 const bodyParser = require('body-parser');
 
@@ -46,8 +47,14 @@ app.get('/fetch', (req, res) => {
  */
 app.get('/readfile', (req, res) => {
     const filename = req.query.filename;
+    const ROOT = path.resolve('/safe/directory'); // Define a safe root directory
     try {
-        const data = fs.readFileSync(filename, 'utf8'); // ⚠️ UNSAFE: Allows path traversal attacks
+        const filePath = path.resolve(ROOT, filename);
+        if (!filePath.startsWith(ROOT)) {
+            res.status(400).send('Invalid file path');
+            return;
+        }
+        const data = fs.readFileSync(filePath, 'utf8');
         res.send(data);
     } catch (error) {
         res.status(500).send('Error reading file');


### PR DESCRIPTION
Potential fix for [https://github.com/Kwstubbs/CodeQLTester/security/code-scanning/2](https://github.com/Kwstubbs/CodeQLTester/security/code-scanning/2)

To fix the problem, we need to ensure that the file path derived from user input is validated and restricted to a safe directory. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with a predefined root directory. This will prevent directory traversal attacks and ensure that only files within the allowed directory can be accessed.

1. Define a root directory where the files are allowed to be read from.
2. Normalize the user-provided path using `path.resolve`.
3. Check if the normalized path starts with the root directory.
4. If the path is valid, proceed to read the file; otherwise, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
